### PR TITLE
feat: rax-app support css modules

### DIFF
--- a/.github/workflows/beta-publisher.yml
+++ b/.github/workflows/beta-publisher.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: nelonoel/branch-name@v1
       - uses: actions/setup-node@v1
         with:
           node-version: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
         node-version: [10.x]
     steps:
       - uses: actions/checkout@v2
-      - uses: nelonoel/branch-name@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ English | [简体中文](./README_zh-CN.md)
   <a href="https://www.npmjs.com/package/rax-app"><img src="https://badgen.net/npm/dm/rax-app" alt="Downloads"></a>
   <a href="https://www.npmjs.com/package/rax-app"><img src="https://badgen.net/npm/v/rax-app" alt="Version"></a>
   <a href="/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="GitHub license" /></a>
-  <a href="https://github.com/raxjs/rax-scripts/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
-  <a href="https://gitter.im/raxjs/rax-scripts"><img src="https://badges.gitter.im/raxjs/rax-scripts.svg" alt="Gitter" /></a>
+  <a href="https://github.com/raxjs/rax-app/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
+  <a href="https://gitter.im/raxjs/rax-app"><img src="https://badges.gitter.im/raxjs/rax-app.svg" alt="Gitter" /></a>
 </p>
 
 > An universal framework based on Rax
@@ -13,9 +13,9 @@ English | [简体中文](./README_zh-CN.md)
 ## Features
 
 - 🐂  **Universal**：Support Web/MiniApp/Kraken
-- 🐴  **App lifecycle**：Provide usePageShow、usePageHide etc.
-- 🐒  **Engineering**：Out of the box support for ES6+、TypeScript、Less、Sass、 CSS Modules，etc
-- 🦊  **Routing**：Powerful Routing System, supports configured routing and conventions routing
+- 🐴  **App lifecycle**：Provide useS6+、TypeScript、Less、Sass、 CSS Modules，etc
+- 🦊  **Routing**：Powerful Routing System, supporPageShow、usePageHide etc.
+- 🐒  **Engineering**：Out of the box support for Ets configured routing and conventions routing
 - 🐯  **State management**：Built-in icestore, lightweight state management solution based on React Hooks
 - 🐦  **Config**：Modes and Environment Variables configuration in the config file
 - 🦁  **Application configuration**：Provide powerful and extensible application configuration
@@ -34,10 +34,10 @@ We recommend creating a new icejs app using [Iceworks](https://marketplace.visua
 
 ### Setup by CLI
 
-We recommend creating a new icejs app using create-ice, which sets up everything automatically for you. To create a project, run:
+Use npm init:
 
 ```bash
-$ npm init ice <project-name>
+$ npm init rax <project-name>
 ```
 
 `npm init <initializer>` is available in npm 6+
@@ -52,14 +52,12 @@ $ npm run start # running on http://localhost:3333.
 
 It's as simple as that!
 
-
 ## Examples
 
 - [with-rax](https://github.com/raxjs/rax-scripts/tree/master/examples/with-rax)
 - [with-rax-mpa](https://github.com/raxjs/rax-scripts/tree/master/examples/with-rax-mpa)
 - [with-rax-store](https://github.com/raxjs/rax-scripts/tree/master/examples/with-rax-store)
 - [with-rax-miniapp-compile](https://github.com/raxjs/rax-scripts/tree/master/examples/with-rax-miniapp-compile)
-
 
 ## Ecosystem
 
@@ -98,10 +96,8 @@ It's as simple as that!
 
 ## Community
 
-| DingTalk community                               | GitHub issues |  Gitter |
-|-------------------------------------|--------------|---------|
-| <a href="https://img.alicdn.com/tfs/TB1xmE8p7T2gK0jSZPcXXcKkpXa-387-505.png"><img src="https://img.alicdn.com/tfs/TB1xmE8p7T2gK0jSZPcXXcKkpXa-387-505.png" width="150" /></a> | [issues]     | [gitter]|
+| DingTalk community                  | GitHub issues |
+|-------------------------------------|--------------|
+| <a href="https://img.alicdn.com/tfs/TB1xmE8p7T2gK0jSZPcXXcKkpXa-387-505.png"><img src="https://img.alicdn.com/tfs/TB1xmE8p7T2gK0jSZPcXXcKkpXa-387-505.png" width="150" /></a> | [issues] |
 
-[issues]: https://github.com/raxjs/rax-scripts/issues
-[gitter]: https://gitter.im/rax-scripts/rax-scripts
-
+[issues]: https://github.com/raxjs/rax-app/issues

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -13,24 +13,14 @@
 ## 特性
 
 - 🐂  **多端**：支持 Web、小程序、Kraken 等容器运行
-
 - 🐴  **完整的应用生命周期**：提供 usePageShow、usePageHide 等钩子
-
 - 🐒  **工程**：开箱即用的工程配置，支持 ES6+、TypeScript、样式方案（Less/Sass/CSS Modules）等
-
 - 🦊  **路由**：默认使用配置式路由，同时支持约定式路由
-
 - 🐯  **数据流**：内置集成 icestore，基于 React Hooks 的轻量级状态管理方案
-
 - 🐦  **环境配置**：内置集成 config， 支持多环境变量的配置
-
 - 🦁  **应用配置**：提供强大的和可扩展的应用程序配置
-
 - 🐌  **插件体系**：提供插件机制，可以扩展框架的核心功能
-
 - 🐘  **TypeScript**：默认使用 TypeScript 
-
-  
 
 ## 快速开始
 
@@ -77,8 +67,6 @@ $ npm run start # running on http://localhost:3333.
 | [miniapp] | [![miniapp-status]][miniapp-package] | [docs][miniapp-docs] | 基于 Rax 的小程序双引擎方案 |
 | [icestore] | [![icestore-status]][icestore-package] | [docs][icestore-docs] | 简单友好的轻量级状态管理方案 |
 | [iceworks]| [![iceworks-status]][iceworks-package] | [docs][iceworks-docs] | 可视化智能开发助手 |
-
-
 
 [rax]: https://github.com/alibaba/rax
 [rax-app]: https://github.com/raxjs/rax-scripts

--- a/examples/with-rax-miniapp-compile/README.md
+++ b/examples/with-rax-miniapp-compile/README.md
@@ -1,3 +1,1 @@
 # with rax miniapp compile
-
-https://github.com/ice-lab/icejs/tree/master/examples

--- a/examples/with-rax-mpa/README.md
+++ b/examples/with-rax-mpa/README.md
@@ -1,3 +1,1 @@
 # with rax mpa
-
-https://github.com/ice-lab/icejs/tree/master/examples

--- a/examples/with-rax-store/README.md
+++ b/examples/with-rax-store/README.md
@@ -1,3 +1,1 @@
 # with rax
-
-https://github.com/ice-lab/icejs/tree/master/examples

--- a/examples/with-rax-style/README.md
+++ b/examples/with-rax-style/README.md
@@ -1,0 +1,15 @@
+# rax-app-ts
+
+## Getting Started
+
+### `npm run start`
+
+Runs the app in development mode.
+
+Open [http://localhost:9999](http://localhost:9999) to view it in the browser.
+
+The page will reload if you make edits.
+
+### `npm run build`
+
+Builds the app for production to the `build` folder.

--- a/examples/with-rax-style/README.md
+++ b/examples/with-rax-style/README.md
@@ -1,15 +1,1 @@
-# rax-app-ts
-
-## Getting Started
-
-### `npm run start`
-
-Runs the app in development mode.
-
-Open [http://localhost:9999](http://localhost:9999) to view it in the browser.
-
-The page will reload if you make edits.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.
+# with-style

--- a/examples/with-rax-style/build.json
+++ b/examples/with-rax-style/build.json
@@ -1,8 +1,8 @@
 {
   "inlineStyle": false,
   "targets": [
-    // "web",
-    // "weex",
+    "web",
+    "weex",
     "miniapp"
   ],
   "miniapp": {

--- a/examples/with-rax-style/build.json
+++ b/examples/with-rax-style/build.json
@@ -1,0 +1,11 @@
+{
+  "inlineStyle": false,
+  "targets": [
+    // "web",
+    // "weex",
+    "miniapp"
+  ],
+  "miniapp": {
+    "buildType": "compile"
+  }
+}

--- a/examples/with-rax-style/package.json
+++ b/examples/with-rax-style/package.json
@@ -1,0 +1,17 @@
+{
+  "scripts": {
+    "build": "rax-app build",
+    "start": "rax-app start",
+    "lint": "eslint --ext .js --ext .jsx ./"
+  },
+  "dependencies": {
+    "rax": "^1.1.0",
+    "rax-document": "^0.1.0",
+    "rax-image": "^2.0.0",
+    "rax-link": "^1.0.1",
+    "rax-text": "^1.0.0",
+    "rax-view": "^1.0.0"
+  },
+  "devDependencies": {
+  }
+}

--- a/examples/with-rax-style/package.json
+++ b/examples/with-rax-style/package.json
@@ -13,5 +13,6 @@
     "rax-view": "^1.0.0"
   },
   "devDependencies": {
+    "miniapp-render": "^1.3.0"
   }
 }

--- a/examples/with-rax-style/src/app.json
+++ b/examples/with-rax-style/src/app.json
@@ -1,0 +1,11 @@
+{
+  "routes": [
+    {
+      "path": "/",
+      "source": "pages/Home/index"
+    }
+  ],
+  "window": {
+    "title": "Rax App"
+  }
+}

--- a/examples/with-rax-style/src/app.ts
+++ b/examples/with-rax-style/src/app.ts
@@ -1,0 +1,4 @@
+import { runApp } from 'rax-app';
+import appConfig from './app.json';
+
+runApp(appConfig);

--- a/examples/with-rax-style/src/components/LogoCss/index.css
+++ b/examples/with-rax-style/src/components/LogoCss/index.css
@@ -1,0 +1,8 @@
+.css-con {
+  background-color: blue;
+}
+.logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/with-rax-style/src/components/LogoCss/index.tsx
+++ b/examples/with-rax-style/src/components/LogoCss/index.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'rax';
 import Image from 'rax-image';
-
+import View from 'rax-view';
+import Text from 'rax-text';
 import './index.css';
 
 interface LogoProps {
@@ -11,12 +12,12 @@ export default (props: LogoProps) => {
   const { uri } = props;
   const source = { uri };
   return (
-    <div className="css-con">
-      CSS 蓝色
+    <View className="css-con">
+      <Text>CSS 蓝色</Text>
       <Image
         className="logo"
         source={source}
       />
-    </div>
+    </View>
   );
 }

--- a/examples/with-rax-style/src/components/LogoCss/index.tsx
+++ b/examples/with-rax-style/src/components/LogoCss/index.tsx
@@ -1,0 +1,22 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+
+import './index.css';
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return (
+    <div className="css-con">
+      CSS 蓝色
+      <Image
+        className="logo"
+        source={source}
+      />
+    </div>
+  );
+}

--- a/examples/with-rax-style/src/components/LogoCssModule/index.module.css
+++ b/examples/with-rax-style/src/components/LogoCssModule/index.module.css
@@ -1,0 +1,8 @@
+.con {
+  background-color: green;
+}
+.logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/with-rax-style/src/components/LogoCssModule/index.tsx
+++ b/examples/with-rax-style/src/components/LogoCssModule/index.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'rax';
 import Image from 'rax-image';
-
+import View from 'rax-view';
+import Text from 'rax-text';
 import styles from './index.module.css';
 
 interface LogoProps {
@@ -11,12 +12,12 @@ export default (props: LogoProps) => {
   const { uri } = props;
   const source = { uri };
   return (
-    <div className={styles.con}>
-      CSS Modules 绿色
+    <View className={styles.con}>
+      <Text>CSS Modules 绿色</Text>
       <Image
         className={styles.logo}
         source={source}
       />
-    </div>
+    </View>
   );
 }

--- a/examples/with-rax-style/src/components/LogoCssModule/index.tsx
+++ b/examples/with-rax-style/src/components/LogoCssModule/index.tsx
@@ -1,0 +1,22 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+
+import styles from './index.module.css';
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return (
+    <div className={styles.con}>
+      CSS Modules 绿色
+      <Image
+        className={styles.logo}
+        source={source}
+      />
+    </div>
+  );
+}

--- a/examples/with-rax-style/src/components/LogoLess/index.less
+++ b/examples/with-rax-style/src/components/LogoLess/index.less
@@ -1,3 +1,9 @@
 .less-con {
   background-color: red;
 }
+
+.logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/with-rax-style/src/components/LogoLess/index.less
+++ b/examples/with-rax-style/src/components/LogoLess/index.less
@@ -1,0 +1,3 @@
+.less-con {
+  background-color: red;
+}

--- a/examples/with-rax-style/src/components/LogoLess/index.tsx
+++ b/examples/with-rax-style/src/components/LogoLess/index.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'rax';
 import Image from 'rax-image';
-
+import View from 'rax-view';
+import Text from 'rax-text';
 // import './index.css';
 import './index.less';
 
@@ -14,12 +15,12 @@ export default (props: LogoProps) => {
   const { uri } = props;
   const source = { uri };
   return (
-    <div className="less-con">
-      LogoLess 红色
+    <View className="less-con">
+      <Text>LogoLess 红色</Text>
       <Image
         className="logo"
         source={source}
       />
-    </div>
+    </View>
   );
 }

--- a/examples/with-rax-style/src/components/LogoLess/index.tsx
+++ b/examples/with-rax-style/src/components/LogoLess/index.tsx
@@ -1,0 +1,25 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+
+// import './index.css';
+import './index.less';
+
+// console.log(222, styles)
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return (
+    <div className="less-con">
+      LogoLess 红色
+      <Image
+        className="logo"
+        source={source}
+      />
+    </div>
+  );
+}

--- a/examples/with-rax-style/src/components/LogoLessModule/index.module.less
+++ b/examples/with-rax-style/src/components/LogoLessModule/index.module.less
@@ -1,0 +1,9 @@
+.con {
+  background-color: yellow;
+}
+
+.logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/with-rax-style/src/components/LogoLessModule/index.tsx
+++ b/examples/with-rax-style/src/components/LogoLessModule/index.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'rax';
 import Image from 'rax-image';
-
+import View from 'rax-view';
+import Text from 'rax-text';
 // import './index.css';
 import styles from './index.module.less';
 
@@ -14,12 +15,12 @@ export default (props: LogoProps) => {
   const { uri } = props;
   const source = { uri };
   return (
-    <div className={styles.con}>
-      logoLessModule 黄色
+    <View className={styles.con}>
+      <Text>logoLessModule 黄色</Text>
       <Image
         className={styles.logo}
         source={source}
       />
-    </div>
+    </View>
   );
 }

--- a/examples/with-rax-style/src/components/LogoLessModule/index.tsx
+++ b/examples/with-rax-style/src/components/LogoLessModule/index.tsx
@@ -1,0 +1,25 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+
+// import './index.css';
+import styles from './index.module.less';
+
+// console.log(222, styles)
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return (
+    <div className={styles.con}>
+      logoLessModule 黄色
+      <Image
+        className={styles.logo}
+        source={source}
+      />
+    </div>
+  );
+}

--- a/examples/with-rax-style/src/components/LogoSass/index.scss
+++ b/examples/with-rax-style/src/components/LogoSass/index.scss
@@ -1,0 +1,9 @@
+.sass-con {
+  background-color: black;
+  color: white;
+}
+.logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/with-rax-style/src/components/LogoSass/index.tsx
+++ b/examples/with-rax-style/src/components/LogoSass/index.tsx
@@ -1,0 +1,22 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+
+import './index.scss';
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return (
+    <div className="sass-con">
+      Sass 黑色
+      <Image
+        className="logo"
+        source={source}
+      />
+    </div>
+  );
+}

--- a/examples/with-rax-style/src/components/LogoSass/index.tsx
+++ b/examples/with-rax-style/src/components/LogoSass/index.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'rax';
 import Image from 'rax-image';
-
+import View from 'rax-view';
+import Text from 'rax-text';
 import './index.scss';
 
 interface LogoProps {
@@ -11,12 +12,12 @@ export default (props: LogoProps) => {
   const { uri } = props;
   const source = { uri };
   return (
-    <div className="sass-con">
-      Sass 黑色
+    <View className="sass-con">
+      <Text>Sass 黑色</Text>
       <Image
         className="logo"
         source={source}
       />
-    </div>
+    </View>
   );
 }

--- a/examples/with-rax-style/src/components/LogoSassModule/index.module.scss
+++ b/examples/with-rax-style/src/components/LogoSassModule/index.module.scss
@@ -1,0 +1,9 @@
+.con {
+  background-color: purple;
+}
+
+.logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/with-rax-style/src/components/LogoSassModule/index.tsx
+++ b/examples/with-rax-style/src/components/LogoSassModule/index.tsx
@@ -1,6 +1,8 @@
 import { createElement } from 'rax';
 import Image from 'rax-image';
 import styles from './index.module.scss';
+import View from 'rax-view';
+import Text from 'rax-text';
 
 interface LogoProps {
   uri: string;
@@ -10,12 +12,12 @@ export default (props: LogoProps) => {
   const { uri } = props;
   const source = { uri };
   return (
-    <div className={styles.con}>
-      logoSassModule purple
+    <View className={styles.con}>
+      <Text>logoSassModule purple</Text>
       <Image
         className={styles.logo}
         source={source}
       />
-    </div>
+    </View>
   );
 }

--- a/examples/with-rax-style/src/components/LogoSassModule/index.tsx
+++ b/examples/with-rax-style/src/components/LogoSassModule/index.tsx
@@ -1,0 +1,21 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+import styles from './index.module.scss';
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return (
+    <div className={styles.con}>
+      logoSassModule purple
+      <Image
+        className={styles.logo}
+        source={source}
+      />
+    </div>
+  );
+}

--- a/examples/with-rax-style/src/document/index.jsx
+++ b/examples/with-rax-style/src/document/index.jsx
@@ -1,0 +1,21 @@
+import { createElement } from 'rax';
+import { Root, Style, Script } from 'rax-document';
+
+function Document() {
+  return (
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover" />
+        <title>@ali/rax-css</title>
+        <Style />
+      </head>
+      <body>
+        {/* root container */}
+        <Root />
+        <Script />
+      </body>
+    </html>
+  );
+}
+export default Document;

--- a/examples/with-rax-style/src/pages/Home/index.tsx
+++ b/examples/with-rax-style/src/pages/Home/index.tsx
@@ -1,0 +1,23 @@
+import { createElement } from 'rax';
+import View from 'rax-view';
+
+import Logo from '../../components/LogoCss';
+import Logo2 from '../../components/LogoCssModule';
+import Logo3 from '../../components/LogoLess';
+import Logo4 from '../../components/LogoLessModule';
+import Logo5 from '../../components/LogoSass';
+import Logo6 from '../../components/LogoSassModule';
+
+export default function Home() {
+  const source = '//gw.alicdn.com/tfs/TB1MRC_cvb2gK0jSZK9XXaEgFXa-1701-1535.png';
+  return (
+    <View>
+      <Logo uri={source} />
+      <Logo2 uri={source} />
+      <Logo3 uri={source} />
+      <Logo4 uri={source} />
+      <Logo5 uri={source} />
+      <Logo6 uri={source} />
+    </View>
+  );
+}

--- a/examples/with-rax-style/src/typings.d.ts
+++ b/examples/with-rax-style/src/typings.d.ts
@@ -1,0 +1,12 @@
+declare module '*.module.scss' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+declare module '*.module.less' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/examples/with-rax-style/tsconfig.json
+++ b/examples/with-rax-style/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "esNext",
     "target": "es2015",
     "outDir": "build",
-    "jsx": "react",
+    "jsx": "preserve",
     "jsxFactory": "createElement",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/examples/with-rax-style/tsconfig.json
+++ b/examples/with-rax-style/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "esNext",
+    "target": "es2015",
+    "outDir": "build",
+    "jsx": "react",
+    "jsxFactory": "createElement",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "rax-app": [".rax/index.ts"],
+      "rax": ["node_modules/@types/rax"]
+    }
+  },
+  "include": ["src/*", ".rax"],
+  "exclude": ["build"]
+}

--- a/examples/with-rax/README.md
+++ b/examples/with-rax/README.md
@@ -1,3 +1,1 @@
 # with rax
-
-https://github.com/ice-lab/icejs/tree/master/examples

--- a/packages/rax-babel-config/package.json
+++ b/packages/rax-babel-config/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-jsx-list": "^0.1.0",
     "babel-plugin-transform-jsx-memo": "^0.1.2",
     "babel-plugin-transform-jsx-slot": "^0.1.1",
-    "babel-plugin-transform-jsx-stylesheet": "^1.0.0",
+    "babel-plugin-transform-jsx-stylesheet": "^0.6.8",
     "babel-plugin-transform-jsx-to-html": "^0.1.0",
     "chalk": "^2.4.2"
   }

--- a/packages/rax-babel-config/package.json
+++ b/packages/rax-babel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-babel-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "rax base babel config",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -40,7 +40,7 @@
     "babel-plugin-transform-jsx-list": "^0.1.0",
     "babel-plugin-transform-jsx-memo": "^0.1.2",
     "babel-plugin-transform-jsx-slot": "^0.1.1",
-    "babel-plugin-transform-jsx-stylesheet": "^0.6.8",
+    "babel-plugin-transform-jsx-stylesheet": "^1.0.0",
     "babel-plugin-transform-jsx-to-html": "^0.1.0",
     "chalk": "^2.4.2"
   }

--- a/packages/rax-babel-config/package.json
+++ b/packages/rax-babel-config/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-jsx-list": "^0.1.0",
     "babel-plugin-transform-jsx-memo": "^0.1.2",
     "babel-plugin-transform-jsx-slot": "^0.1.1",
-    "babel-plugin-transform-jsx-stylesheet": "^0.6.8",
+    "babel-plugin-transform-jsx-stylesheet": "^1.0.1",
     "babel-plugin-transform-jsx-to-html": "^0.1.0",
     "chalk": "^2.4.2"
   }


### PR DESCRIPTION
## 背景

脚手架默认 inlineStyle 改为 false 之后，用 css 冲突概率很大，因此希望统一成 CSS Module，但是如果开发者把 inlineStyle 改为 true 就报错了，因此 babel-plugin-transform-jsx-stylesheet@1.0 支持了 inlineStyle+CSS Module https://github.com/raxjs/rax-scripts/pull/424 

## 影响

```diff
- import './index.css';
+ import styles from './index.module.css';

- <div className="logo" />
+ <div className={styles.logo} />  
```

## 后续 Action

- rax-materials 脚手架默认改为 CSS Module 写法