### PR TITLE
fix: chunk load

### DIFF
--- a/examples/basic-split-chunk/README.md
+++ b/examples/basic-split-chunk/README.md
@@ -1,0 +1,1 @@
+# basic split chunk

--- a/examples/basic-split-chunk/build.json
+++ b/examples/basic-split-chunk/build.json
@@ -1,0 +1,6 @@
+{
+  "targets": [
+    "web"
+  ],
+  "minify": false
+}

--- a/examples/basic-split-chunk/package.json
+++ b/examples/basic-split-chunk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "with-rax",
+  "description": "rax example",
+  "dependencies": {
+    "rax": "^1.1.0",
+    "rax-document": "^0.1.0",
+    "rax-image": "^2.0.0",
+    "rax-link": "^1.0.1",
+    "rax-text": "^2.0.0",
+    "rax-view": "^2.0.0",
+    "rax-waterfall": "^1.1.2"
+  },
+  "devDependencies": {
+    "@types/rax": "^1.0.0"
+  },
+  "scripts": {
+    "start": "rax-app start",
+    "build": "rax-app build"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  }
+}

--- a/examples/basic-split-chunk/src/app.json
+++ b/examples/basic-split-chunk/src/app.json
@@ -1,0 +1,15 @@
+{
+  "routes": [
+    {
+      "path": "/",
+      "source": "pages/Home/index"
+    },
+    {
+      "path": "/about",
+      "source": "pages/About/index"
+    }
+  ],
+  "window": {
+    "title": "Rax App"
+  }
+}

--- a/examples/basic-split-chunk/src/app.ts
+++ b/examples/basic-split-chunk/src/app.ts
@@ -1,0 +1,3 @@
+import { runApp } from 'rax-app';
+
+runApp({});

--- a/examples/basic-split-chunk/src/components/Logo/index.css
+++ b/examples/basic-split-chunk/src/components/Logo/index.css
@@ -1,0 +1,5 @@
+.rax-demo-logo {
+  width: 200rpx;
+  height: 180rpx;
+  margin-bottom: 20rpx;
+}

--- a/examples/basic-split-chunk/src/components/Logo/index.tsx
+++ b/examples/basic-split-chunk/src/components/Logo/index.tsx
@@ -1,0 +1,14 @@
+import { createElement } from 'rax';
+import Image from 'rax-image';
+
+import './index.css';
+
+interface LogoProps {
+  uri: string;
+}
+
+export default (props: LogoProps) => {
+  const { uri } = props;
+  const source = { uri };
+  return <Image className="rax-demo-logo" source={source} />;
+};

--- a/examples/basic-split-chunk/src/document/index.tsx
+++ b/examples/basic-split-chunk/src/document/index.tsx
@@ -1,0 +1,24 @@
+import { createElement } from 'rax';
+import { Root, Style, Script } from 'rax-document';
+
+function Document() {
+  return (
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <meta
+          name="viewport"
+          content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover"
+        />
+        <title>rax-materials-basic-app</title>
+        <Style />
+      </head>
+      <body>
+        {/* root container */}
+        <Root />
+        <Script />
+      </body>
+    </html>
+  );
+}
+export default Document;

--- a/examples/basic-split-chunk/src/pages/About/index.module.css
+++ b/examples/basic-split-chunk/src/pages/About/index.module.css
@@ -1,0 +1,16 @@
+.rax-demo-home {
+  align-items: center;
+  margin-top: 200rpx;
+}
+
+.rax-demo-title {
+  font-size: 45rpx;
+  font-weight: bold;
+  margin: 20rpx 0;
+}
+
+.rax-demo-info {
+  font-size: 36rpx;
+  margin: 8rpx 0;
+  color: #555;
+}

--- a/examples/basic-split-chunk/src/pages/About/index.tsx
+++ b/examples/basic-split-chunk/src/pages/About/index.tsx
@@ -1,0 +1,52 @@
+import { createElement } from 'rax';
+import View from 'rax-view';
+import Text from 'rax-text';
+import Waterfall from 'rax-waterfall';
+import { history } from 'rax-app';
+
+import styles from './index.module.css';
+
+let dataSource = [
+  { height: 550, item: {} },
+  { height: 624, item: {} },
+  { height: 708, item: {} },
+  { height: 600, item: {} },
+  { height: 300, item: {} },
+  { height: 100, item: {} },
+  { height: 400, item: {} },
+  { height: 550, item: {} },
+  { height: 624, item: {} },
+  { height: 708, item: {} },
+  { height: 600, item: {} },
+  { height: 300, item: {} },
+  { height: 100, item: {} },
+  { height: 400, item: {} }
+];
+
+export default function Home() {
+  return (
+    <View className={styles['rax-demo-home']}>
+      <View onClick={() => history.goBack()}>Go back</View>
+      <Waterfall
+        columnWidth={150}
+        columnCount={4}
+        columnGap={50}
+        dataSource={dataSource}
+        renderHeader={() => {
+          return [
+            <View key="1" style={{ width: 750, height: 100, backgroundColor: 'yellow', marginBottom: 20 }}>header1</View>,
+            <View key="2" style={{ width: 750, height: 100, backgroundColor: 'green', marginBottom: 20 }}>header2</View>
+          ];
+        }}
+        renderFooter={() => {
+          return <View key="3" style={{ width: 750, height: 300, backgroundColor: 'blue', marginTop: 20 }}>footer1</View>;
+        }}
+        renderItem={(item, index) => {
+          return (<View style={{ height: item.height, backgroundColor: 'red', marginBottom: 20 }}>
+            <Text>{index}</Text>
+            {/* {index} */}
+          </View>);
+        }} />
+    </View>
+  );
+}

--- a/examples/basic-split-chunk/src/pages/Home/index.module.css
+++ b/examples/basic-split-chunk/src/pages/Home/index.module.css
@@ -1,0 +1,18 @@
+
+.rax-demo-home {
+  flex-direction: row;
+}
+
+.rax-demo-title {
+  font-size: 45rpx;
+  font-weight: bold;
+  margin: 20rpx 0;
+}
+
+.rax-demo-info {
+  font-size: 36rpx;
+  margin: 8rpx 0;
+  color: #555;
+}
+
+

--- a/examples/basic-split-chunk/src/pages/Home/index.tsx
+++ b/examples/basic-split-chunk/src/pages/Home/index.tsx
@@ -1,0 +1,19 @@
+import { createElement } from 'rax';
+import View from 'rax-view';
+import Text from 'rax-text';
+import { history } from 'rax-app';
+
+import styles from './index.module.css';
+import Logo from '../../components/Logo';
+
+export default function Home() {
+  return (
+    <View className={styles['rax-demo-home']}>
+      <Logo uri="//gw.alicdn.com/tfs/TB1MRC_cvb2gK0jSZK9XXaEgFXa-1701-1535.png" />
+      <Text className="rax-demo-title">Welcome to Your Rax App</Text>
+      <Text className="rax-demo-info">More information about Rax</Text>
+      <Text className="rax-demo-info">Visit https://rax.js.org</Text>
+      <View onClick={() => history.push('/about')}>Go haha</View>
+    </View>
+  );
+}

--- a/examples/basic-split-chunk/tsconfig.json
+++ b/examples/basic-split-chunk/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "build",
+    "module": "esnext",
+    "target": "es6",
+    "jsx": "preserve",
+    "jsxFactory": "createElement",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "lib": ["es6", "dom"],
+    "sourceMap": true,
+    "allowJs": true,
+    "rootDir": "./",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": false,
+    "importHelpers": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "rax-app": [".rax/index.ts"]
+    }
+  },
+  "include": ["src", ".rax"],
+  "exclude": ["node_modules", "build", "public"]
+}

--- a/packages/plugin-rax-app/src/config/user.config.js
+++ b/packages/plugin-rax-app/src/config/user.config.js
@@ -49,4 +49,9 @@ module.exports = [
     name: 'compileDependencies',
     defaultValue: [''],
   },
+  {
+    name: 'vendor',
+    defaultValue: true,
+    configWebpack: require('../userConfig/vendor'),
+  },
 ];

--- a/packages/plugin-rax-app/src/userConfig/vendor.js
+++ b/packages/plugin-rax-app/src/userConfig/vendor.js
@@ -1,0 +1,13 @@
+module.exports = (config, vendor) => {
+  if (!vendor) {
+    config.optimization.splitChunks({ cacheGroups: {} });
+  } else {
+    // In Rax lazy load mode, all common module need be splited to vendor file
+    config.optimization.splitChunks({ cacheGroups: {
+      vendor: {
+        test: /[\\/]node_modules[\\/]/,
+        enforce: true,
+      },
+    } });
+  }
+};

--- a/packages/plugin-rax-web/src/index.js
+++ b/packages/plugin-rax-web/src/index.js
@@ -50,6 +50,7 @@ module.exports = (api) => {
 
     webpackConfig.output.libraryTarget = 'commonjs2';
     // do not generate vendor.js when compile document
+    // deep copy webpackConfig optimization, because the toConfig method is shallow copy
     webpackConfig.optimization = {
       ...webpackConfig.optimization,
       splitChunks: {

--- a/packages/plugin-rax-web/src/index.js
+++ b/packages/plugin-rax-web/src/index.js
@@ -50,7 +50,13 @@ module.exports = (api) => {
 
     webpackConfig.output.libraryTarget = 'commonjs2';
     // do not generate vendor.js when compile document
-    webpackConfig.optimization.splitChunks.cacheGroups = {};
+    webpackConfig.optimization = {
+      ...webpackConfig.optimization,
+      splitChunks: {
+        ...webpackConfig.optimization.splitChunks,
+        cacheGroups: {},
+      },
+    };
 
     config.plugin('document').use(DocumentPlugin, [
       {


### PR DESCRIPTION
- 修复 document 插件通过 `webpackChainConfig.toConfig` 获取 webpack 配置时，修改了 web 主流程任务配置引用的问题
- 修复 dynamic import 生成 vendor 公共文件时，由于没有强制抽离公共文件，导致 A 页面的公共样式未抽离，A 页面跳转到 B 页面，再返回 A 页面时，B 页面样式污染 A 页面的问题