### PR TITLE
chore: change config

### DIFF
--- a/packages/plugin-rax-app/src/config/user.config.js
+++ b/packages/plugin-rax-app/src/config/user.config.js
@@ -47,7 +47,7 @@ module.exports = [
   },
   {
     name: 'compileDependencies',
-    defaultValue: [''],
+    defaultValue: [],
   },
   {
     name: 'vendor',

--- a/packages/rax-app-renderer/src/renderer.tsx
+++ b/packages/rax-app-renderer/src/renderer.tsx
@@ -170,7 +170,7 @@ function _renderApp(context, options) {
       return render(
         appInstance,
         rootEl,
-        { driver, hydrate: webConfig.snapshot || webConfig.ssr },
+        { driver, hydrate: webConfig.hydrate || webConfig.snapshot || webConfig.ssr },
       );
     });
 }

--- a/packages/rax-webpack-config/src/webpack.build.js
+++ b/packages/rax-webpack-config/src/webpack.build.js
@@ -15,9 +15,6 @@ module.exports = (config) => {
       parallel: true,
       extractComments: false,
       terserOptions: {
-        compress: {
-          unused: false,
-        },
         output: {
           ascii_only: true,
           comments: 'some',


### PR DESCRIPTION
- `compileDependencies` 默认值改为 `[]`，在目前 node_modules 分端代码移除没生效的情况下，考虑编译速度，默认值应该是 `[]`
- 支持配置 `hydrate: true`
- TerserPlugin 配置默认改为移除未使用到的代码