### PR TITLE
fix: babel need transform generator syntactic sugar

### DIFF
--- a/packages/rax-babel-config/src/index.js
+++ b/packages/rax-babel-config/src/index.js
@@ -15,7 +15,6 @@ module.exports = (userOptions = {}) => {
     styleSheet,
     jsxPlus = true,
     jsxToHtml,
-    disableRegenerator = false,
     // preset-env modules options
     modules,
   } = options;
@@ -31,7 +30,6 @@ module.exports = (userOptions = {}) => {
           include: [
             'transform-computed-properties',
           ],
-          exclude: disableRegenerator ? ['transform-regenerator'] : [],
         },
       ],
       [


### PR DESCRIPTION
`disableRegenerator` 只是在小程序中不注入 regenerate-runtime 依赖，babel 依然需要在小程序中转换 generator 语法糖，避免微信报错