### PR TITLE
fix: generate html when insert extra scripts

### DIFF
--- a/packages/plugin-rax-web/src/__tests__/htmlStructure.test.ts
+++ b/packages/plugin-rax-web/src/__tests__/htmlStructure.test.ts
@@ -1,0 +1,80 @@
+import {
+  addSpmA,
+  addSpmB,
+  getBuiltInHtmlTpl,
+  getInjectedHTML,
+  injectHTML,
+  insertScriptsByInfo,
+} from '../utils/htmlStructure';
+
+describe('generate html structure', () => {
+  it('should return SPM A string', () => {
+    expect(addSpmA('a1234')).toEqual('<meta name="data-spm" content="a1234" />');
+  });
+
+  it('should add SPM B', () => {
+    expect(addSpmB('b1234')).toEqual('data-spm="b1234"');
+  });
+
+  it('should generate html', () => {
+    injectHTML('script', [
+      '<script src="https://g.alicdn.com/code/lib/rax/1.1.4/rax.min.js"></script>',
+      '<script src="https://g.alicdn.com/code/lib/react/17.0.0/react.min.js"></script>',
+    ]);
+    injectHTML('meta', [
+      '<meta name="apple-mobile-web-app-capable" content="yes">',
+      '<meta name="apple-mobile-web" content="yes">',
+    ]);
+    injectHTML('link', [
+      '<link rel="dns-prefetch" href="https://github.githubassets.com">',
+      '<link rel="dns-prefetch" href="https://avatars.githubusercontent.com">',
+    ]);
+    insertScriptsByInfo([
+      {
+        src: 'https://g.alicdn.com/ali-lib/appear-polyfill/0.1.2/index.js',
+      },
+    ]);
+    const injectedHTML = getInjectedHTML();
+
+    expect(
+      getBuiltInHtmlTpl({
+        doctype: '<!DOCTYPE html>',
+        injectedHTML,
+        initialHTML: '',
+        assets: {
+          scripts: ['/home.js'],
+          links: ['/home.css'],
+        },
+        spmA: 'a1234',
+        spmB: 'b1234',
+      }),
+    ).toEqual(`
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset=\"utf-8\" />
+      <meta name="data-spm" content="a1234" />
+      <meta name=\"viewport\" content=\"width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover\" />
+      <meta name=\"apple-mobile-web-app-capable\" content=\"yes\">
+<meta name=\"apple-mobile-web\" content=\"yes\">
+
+      <title>undefined</title>
+      <link rel=\"dns-prefetch\" href=\"https://github.githubassets.com\">
+<link rel=\"dns-prefetch\" href=\"https://avatars.githubusercontent.com\">
+
+      <link rel=\"stylesheet\" href=\"/home.css\" />
+
+    </head>
+    <body data-spm="b1234">
+      <div id=\"root\"></div>
+      <script src=\"https://g.alicdn.com/code/lib/rax/1.1.4/rax.min.js\"></script>
+<script src=\"https://g.alicdn.com/code/lib/react/17.0.0/react.min.js\"></script>
+<script src=\"https://g.alicdn.com/ali-lib/appear-polyfill/0.1.2/index.js\" ></script>
+
+      <script crossorigin=\"anonymous\" type=\"application/javascript\" src=\"/home.js\"></script>
+
+    </body>
+  </html>
+`);
+  });
+});

--- a/packages/plugin-rax-web/src/utils/htmlStructure.ts
+++ b/packages/plugin-rax-web/src/utils/htmlStructure.ts
@@ -4,21 +4,21 @@ let scripts = [];
 let links = [];
 let metas = [];
 
-function addSpmA(spmA) {
+export function addSpmA(spmA) {
   if (!spmA) return '';
   return `<meta name="data-spm" content="${spmA}" />`;
 }
 
-function addSpmB(spmB) {
+export function addSpmB(spmB) {
   if (!spmB) return '';
   return `data-spm="${spmB}"`;
 }
 
-function addStaticSource(sources: string[]) {
+export function addStaticSource(sources: string[]) {
   return sources.reduce((prev, current) => `${prev}${current}\n`, '');
 }
 
-function addScriptsBySource(sources: string[]) {
+export function addScriptsBySource(sources: string[]) {
   return sources.reduce(
     (prev, current) =>
       `${prev}${`<script crossorigin="anonymous" type="application/javascript" src="${current}"></script>`}\n`,
@@ -26,7 +26,7 @@ function addScriptsBySource(sources: string[]) {
   );
 }
 
-function addLinksBySource(sources: string[]) {
+export function addLinksBySource(sources: string[]) {
   return sources.reduce((prev, current) => `${prev}${`<link rel="stylesheet" href="${current}" />`}\n`, '');
 }
 

--- a/packages/plugin-rax-web/src/utils/htmlStructure.ts
+++ b/packages/plugin-rax-web/src/utils/htmlStructure.ts
@@ -62,22 +62,22 @@ export function getBuiltInHtmlTpl(htmlInfo: IHtmlInfo) {
 }
 
 export function insertScripts(customScripts) {
-  scripts = [...scripts, customScripts];
+  scripts = [...scripts, ...customScripts];
 }
 
 export function insertLinks(customLinks) {
-  links = [...links, customLinks];
+  links = [...links, ...customLinks];
 }
 
 export function insertMetas(customMetas) {
-  metas = [...metas, customMetas];
+  metas = [...metas, ...customMetas];
 }
 
 export function insertScriptsByInfo(customScripts) {
   insertScripts(
     customScripts.map((scriptInfo) => {
-      const attrStr = Object.keys(scriptInfo).reduce((curr, next) => `${curr} ${next}=${scriptInfo[next]} `, '');
-      return `<script${attrStr} />`;
+      const attrStr = Object.keys(scriptInfo).reduce((curr, next) => `${curr} ${next}="${scriptInfo[next]}" `, '');
+      return `<script${attrStr}></script>`;
     }),
   );
 }


### PR DESCRIPTION
cheerio 会 format 不符合规范的 html 结构，在移除 cheerio 之后暴露拼装 HTML 不合规范的问题