### PR TITLE
fix(platform-loader): fix platform-loader jsx and typescript comflict…

### DIFF
--- a/packages/platform-loader/src/TraverseImport.js
+++ b/packages/platform-loader/src/TraverseImport.js
@@ -8,6 +8,7 @@ const { codeFrameColumns } = require('@babel/code-frame');
 module.exports = function traverseImport(options, inputSource, sourceMapOption) {
   let specified; // Collector import specifiers
   let hasPlatformSpecified = false;
+  const { sourceFileName } = sourceMapOption;
 
   const platformMap = {
     weex: ['isWeex'],
@@ -84,8 +85,8 @@ module.exports = function traverseImport(options, inputSource, sourceMapOption) 
     ast = babelParser.parse(inputSource, {
       sourceType: 'module',
       plugins: [
-        'jsx',
-        'typescript',
+        /\.ts$/.test(sourceFileName) ? '' : 'jsx',
+        /\.tsx?$/.test(sourceFileName) ? 'typescript' : '',
         'classProperties',
         'objectRestSpread',
         'optionalCatchBinding',


### PR DESCRIPTION
`@babel/parser` 里同时开启了 `jsx/typescript` 插件，在 `.ts` 文件中使用 `<A>a` 的类型断言语法，会和 `jsx` 语法冲突报错，需要做一下文件后缀的校验，避免加载不必要的插件，比如：

* 后缀为 `.ts` 的时候不加载 `jsx`
* 非 `ts/tsx` 文件不加载 `typescript`

![image](https://user-images.githubusercontent.com/471003/109985010-480aa180-7d3f-11eb-84c3-77c8e97f9345.png)
