### PR TITLE
chore: reduce miniapp size with subPackages

### DIFF
--- a/examples/miniapp-subpackages/package.json
+++ b/examples/miniapp-subpackages/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@iceworks/spec": "^1.0.0",
-    "rax-app": "^3.0.0",
     "eslint": "^6.8.0",
     "prettier": "^2.1.2",
     "stylelint": "^13.7.2"

--- a/examples/miniapp-subpackages/src/pages/Home/module/index.jsx
+++ b/examples/miniapp-subpackages/src/pages/Home/module/index.jsx
@@ -1,6 +1,7 @@
 import { createElement } from 'rax';
 import View from 'rax-view';
 import Text from 'rax-text';
+import { isMiniApp } from 'universal-env';
 
 import styles from './index.module.css';
 
@@ -11,9 +12,15 @@ export default function Home() {
     <View className={styles.homeContainer}>
       <Logo uri="//gw.alicdn.com/tfs/TB1MRC_cvb2gK0jSZK9XXaEgFXa-1701-1535.png" />
       <Text className={styles.homeTitle} onClick={() => {
-        my.navigateTo({
-          url: '/pages/About/module/index'
-        });
+        if (isMiniApp) {
+          my.navigateTo({
+            url: '/pages/About/module/index'
+          });
+        } else {
+          wx.navigateTo({
+            url: '/pages/About/module/index'
+          });
+        }
       }}>点我去到子包页面</Text>
       <Text className={styles.homeInfo}>More information about Rax</Text>
       <Text className={styles.homeInfo}>Visit https://rax.js.org</Text>

--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -13,7 +13,7 @@ const { GET_RAX_APP_WEBPACK_CONFIG, MINIAPP_COMPILED_DIR } = require('./constant
 module.exports = (api) => {
   const { getValue, context, registerTask, onGetWebpackConfig, registerUserConfig } = api;
   const { userConfig } = context;
-  const { targets, inlineStyle } = userConfig;
+  const { targets, inlineStyle, vendor } = userConfig;
 
   const getWebpackBase = getValue(GET_RAX_APP_WEBPACK_CONFIG);
   targets.forEach((target) => {
@@ -74,6 +74,22 @@ module.exports = (api) => {
             entryPath: './src/app',
           });
         } else {
+          const { subPackages } = userConfig[target] || {};
+          if (vendor && subPackages) {
+            const originalSplitChunks = config.optimization.get('splitChunks');
+            config.optimization.splitChunks({
+              ...originalSplitChunks,
+              cacheGroups: {
+                ...originalSplitChunks.cacheGroups,
+                vendor: {
+                  ...(originalSplitChunks.cacheGroups || {}).vendor,
+                  chunks: 'all',
+                  name: 'vendors',
+                },
+              },
+            });
+          }
+
           setConfig(config, {
             api,
             target,


### PR DESCRIPTION
小程序分包模式抽离所有分包公共代码到主包，有效降低分包代码体积

以[简单示例代码](https://github.com/raxjs/rax-app/blob/master/examples/miniapp-subpackages/README.md)为例，压缩后代码从 378kb 下降到 216kb