### PR TITLE
fix: 运行时项目中，编译时组件目录下，是否拷贝npm目录，配置化。

### DIFF
--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -73,7 +73,7 @@ module.exports = (api) => {
             entryPath: './src/app',
           });
         } else {
-          const { subPackages, disableCopyNpm } = userConfig[target] || {};
+          const { subPackages, disableCopyNpm = true } = userConfig[target] || {};
           if (vendor && subPackages) {
             const originalSplitChunks = config.optimization.get('splitChunks');
             config.optimization.splitChunks({
@@ -124,7 +124,7 @@ module.exports = (api) => {
 
             setComponentCompileConfig(
               compiledComponentsChainConfig,
-              { disableCopyNpm: disableCopyNpm === false ? false : true },
+              { disableCopyNpm: disableCopyNpm },
               {
                 target,
                 context,

--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -124,7 +124,7 @@ module.exports = (api) => {
 
             setComponentCompileConfig(
               compiledComponentsChainConfig,
-              { disableCopyNpm: true },
+              { disableCopyNpm: subPackages && subPackages.disableCopyNpm },
               {
                 target,
                 context,

--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -124,7 +124,7 @@ module.exports = (api) => {
 
             setComponentCompileConfig(
               compiledComponentsChainConfig,
-              { disableCopyNpm: subPackages && subPackages.disableCopyNpm },
+              { disableCopyNpm: userConfig[target] && userConfig[target].disableCopyNpm },
               {
                 target,
                 context,

--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -73,7 +73,7 @@ module.exports = (api) => {
             entryPath: './src/app',
           });
         } else {
-          const { subPackages } = userConfig[target] || {};
+          const { subPackages, disableCopyNpm } = userConfig[target] || {};
           if (vendor && subPackages) {
             const originalSplitChunks = config.optimization.get('splitChunks');
             config.optimization.splitChunks({
@@ -124,7 +124,7 @@ module.exports = (api) => {
 
             setComponentCompileConfig(
               compiledComponentsChainConfig,
-              { disableCopyNpm: userConfig[target] && userConfig[target].disableCopyNpm },
+              { disableCopyNpm: disableCopyNpm === false ? false : true },
               {
                 target,
                 context,


### PR DESCRIPTION
运行时项目中，使用编译时组件（miniapp-compiled目录），目录下无法生成npm目录。排查源码后发现，是disableCopyNpm属性在rax-app-->plugin-rax-miniapp下写死为true。PR建议：是否生成npm目录，交给用户配置。