### PR TITLE
fix: miniapp vendor test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+## 3.4.11 (April 1 2021)
+
+- Fix: miniapp vendor test
 ## 3.4.10 (March 31 2021)
 
 - Feat: support set dataPrefetch for every single page in PHA

--- a/packages/plugin-rax-miniapp/CHANGELOG.md
+++ b/packages/plugin-rax-miniapp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.1
+
+- Fix: vendor test
+
 ## v1.3.0
 
 - Feat: support share memory in every common files with miniapp subpackages

--- a/packages/plugin-rax-miniapp/package.json
+++ b/packages/plugin-rax-miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-miniapp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "rax miniapp app plugin",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -91,7 +91,7 @@ module.exports = (api) => {
                   chunks: 'all',
                   name: 'vendors',
                   minChunks: 2,
-                  test(filepath) {
+                  test({ context: filepath }) {
                     // If shareMemory is true, every common files should be splited to vendors.js
                     if (shareMemory) {
                       return true;

--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "description": "command line interface and builtin plugin for rax app",
   "author": "Rax Team",
   "homepage": "https://github.com/alibaba/ice#readme",
@@ -20,7 +20,7 @@
     "build-plugin-rax-store": "1.1.0",
     "build-plugin-rax-app": "6.2.11",
     "build-plugin-rax-kraken": "1.1.1",
-    "build-plugin-rax-miniapp": "1.3.0",
+    "build-plugin-rax-miniapp": "1.3.1",
     "build-plugin-rax-pha": "1.4.0",
     "build-plugin-rax-web": "1.4.0",
     "build-plugin-rax-weex": "1.1.1",


### PR DESCRIPTION
`vendor` test 的参数返回是一个对象，其中的 `context` 属性是文件的绝对路径