### PR TITLE
chore : optimize handle route name

### DIFF
--- a/packages/codemod/CHANELOG.md
+++ b/packages/codemod/CHANELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.2
+
+- Chore: optimize handle route name when it existed name
+
 ## v1.0.1
 
 - Fix: bin file

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-codemod",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Rax codemod scripts",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/codemod/src/transforms/app/app.json.ts
+++ b/packages/codemod/src/transforms/app/app.json.ts
@@ -2,14 +2,17 @@ export default function (fileInfo) {
   const appJSON = JSON.parse(fileInfo.source);
 
   appJSON.routes = appJSON.routes.map((route) => {
-    let name = `pages${route.path}/index`;
-
-    if (route.path === '/') {
+    let name;
+    if (route.name) {
+      name = `pages/${name}`;
+    } else if (route.path === '/') {
       name = 'pages/index';
+    } else {
+      name = `pages${route.path}/index`;
     }
     return {
-      name,
       ...route,
+      name,
     };
   });
 


### PR DESCRIPTION
旧工程 route 中存在 name 时，需要给 name 添加 `pages/`，保证输出目录一致