### PR TITLE
feat(miniapp): copy build result to demo folder

### DIFF
--- a/packages/build-plugin-rax-miniapp-plugin/src/config/getBase.js
+++ b/packages/build-plugin-rax-miniapp-plugin/src/config/getBase.js
@@ -13,6 +13,7 @@ const CopyJsx2mpRuntimePlugin = require('../plugins/miniapp/CopyJsx2mpRuntime');
 const CopyPublicFilePlugin = require('../plugins/miniapp/CopyPublicFile');
 const ProcessPluginJsonPlugin = require('../plugins/miniapp/ProcessPluginJson');
 const GenerateAppCssPlugin = require('../plugins/miniapp/GenerateAppCss');
+const CopyBuildResultPlugin = require('../plugins/miniapp/CopyBuildResult');
 
 const platformConfig = require('./platformConfig');
 const targetPlatformMap = require('./targetPlatformMap');
@@ -24,7 +25,7 @@ const FileLoader = require.resolve('jsx2mp-loader/src/file-loader');
 
 module.exports = (context, target, options = {}, onGetWebpackConfig) => {
   const { platform = targetPlatformMap[target], mode = 'build', disableCopyNpm = false, turnOffSourceMap = false } = options[target] || {};
-  const { rootDir, command } = context;
+  const { rootDir } = context;
   const platformInfo = platformConfig[target];
   const entryPath = './src/index';
   const outputPath = getOutputPath(context, { target });
@@ -171,6 +172,7 @@ module.exports = (context, target, options = {}, onGetWebpackConfig) => {
   config.plugin('removeDefaultResult').use(RemoveDefaultResultPlugin);
   config.plugin('processPluginJson').use(ProcessPluginJsonPlugin, [{ outputPath, rootDir, target }]);
   config.plugin('generateAppCss').use(GenerateAppCssPlugin, [{ outputPath, platformInfo }]);
+  config.plugin('copyBuildResult').use(CopyBuildResultPlugin, [{ mode, outputPath, rootDir, target }]);
 
   if (isPublicFileExist) {
     config.plugin('copyFile').use(CopyPublicFilePlugin, [{ mode, outputPath, rootDir }]);

--- a/packages/build-plugin-rax-miniapp-plugin/src/plugins/miniapp/CopyBuildResult.js
+++ b/packages/build-plugin-rax-miniapp-plugin/src/plugins/miniapp/CopyBuildResult.js
@@ -1,0 +1,21 @@
+const { resolve } = require('path');
+const { copySync } = require('fs-extra');
+
+module.exports = class CopyBuildResultPlugin {
+  constructor({ target, mode = 'build', rootDir = '', outputPath = '' }) {
+    this.target = target;
+    this.mode = mode;
+    this.rootDir = rootDir;
+    this.outputPath = outputPath;
+  }
+
+  apply(compiler) {
+    compiler.hooks.done.tapAsync('CopyBuildResultPlugin', (compilation, callback) => {
+      if (this.mode === 'build') {
+        const demoPluginFolder = resolve(this.rootDir, 'demo', this.target, 'plugin');
+        copySync(this.outputPath, demoPluginFolder);
+      }
+      callback();
+    });
+  }
+};

--- a/packages/jsx2mp-cli/__tests__/component.js
+++ b/packages/jsx2mp-cli/__tests__/component.js
@@ -38,7 +38,7 @@ describe('Component compiled result', () => {
 
   it('should return correct js', () => {
     expect(jsContent).toEqual(
-      '"use strict";var _jsx2mpRuntime=require("./npm/jsx2mp-runtime"),_index=require("./npm/rax-view/lib/index.js"),img="./assets/rax.png",a=0,b=1;function Index(){(0,_index.custom)(),this._updateChildProps("0",{source:{uri:img},c:a&&b,d:img?a:b}),this._updateData({_d0:img,_d1:a,_d2:b}),this._updateMethods({})}var __def__=Index;Component((0,_jsx2mpRuntime.createComponent)(__def__));'
+      '"use strict";var _jsx2mpRuntime=require("./npm/jsx2mp-runtime"),_index=require("./npm/rax-view/lib/index.js"),img="./assets/rax.png",a=0,b=1;function Index(){(0,_index.custom)(),this._updateChildProps("0",{source:{uri:img},c:a&&b,d:img?a:b}),this._updateData({_d0:img,_d1:a,_d2:b}),this._updateMethods({})}var __def__=Index;Component((0,_jsx2mpRuntime.createComponent)(__def__,{}));'
     );
   });
 

--- a/packages/jsx2mp-cli/plugins/runtime.js
+++ b/packages/jsx2mp-cli/plugins/runtime.js
@@ -21,9 +21,7 @@ module.exports = class JSX2MPRuntimePlugin {
     compiler.hooks.emit.tapAsync(
       'JSX2MPRuntimePlugin',
       (compilation, callback) => {
-        const runtimeTargetPath = runtimePackageJSON.miniprogram && runtimePackageJSON.miniprogram[this.platform]
-          ? runtimePackageJSON.miniprogram[this.platform]
-          : runtimePackageJSON.main || 'index.js';
+        const runtimeTargetPath = `dist/jsx2mp-runtime.${this.platform}.esm.js`;
         const sourceFile = require.resolve(join(runtimePackagePath, runtimeTargetPath));
         const targetFile = join(compiler.outputPath, 'npm', runtime + '.js');
 


### PR DESCRIPTION
- [x] 应对淘宝/支付宝小程序云端构建需求，在 npm run build 后将产物 copy 至 demo 文件夹，并在项目根目录增加 mini.project.json 配置 