### PR TITLE
release: v3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+## 3.5.1 (April 29 2021)
+
+- Feat: support pass `props.pageConfig` to page component
+- Feat: throw error when not using the BrowserRouter
+- Chore: `errorBoundary` default value changed to `true`
+
 ## 3.5.0 (April 15 2021)
 
 - Feat: support custom tabbar in MPA

--- a/packages/plugin-ssr/CHANELOG.md
+++ b/packages/plugin-ssr/CHANELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.7
+
+- Feat: add `props.pageConfig` in Rax App SSR page component
+
 ## v1.3.6
 
 - Chore: only remove comment node with build command

--- a/packages/plugin-ssr/package.json
+++ b/packages/plugin-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-ssr",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "",
   "author": "",
   "homepage": "https://github.com/alibaba/ice#readme",
@@ -31,7 +31,7 @@
     "react-dev-utils": "^10.0.0",
     "cheerio": "1.0.0-rc.3",
     "html-minifier": "^4.0.0",
-    "rax-app-renderer": "^2.0.0",
+    "rax-app-renderer": "^2.0.2",
     "@builder/html-generator": "^2.0.0",
     "chalk": "^4.0.0"
   }

--- a/packages/plugin-ssr/src/ssr/EntryLoader.ts
+++ b/packages/plugin-ssr/src/ssr/EntryLoader.ts
@@ -23,7 +23,8 @@ function addImportDocument(code, documentPath) {
 
 function addImportPageComponent(resourcePath, pageConfig) {
   return `import Page from '${formatPath(resourcePath)}';
-  Page.__pageConfig = ${JSON.stringify(pageConfig)};`;
+  Page.__pageConfig = ${JSON.stringify(pageConfig)};
+  `;
 }
 
 function addRunAppDependencies(resourcePath, tempPath) {
@@ -41,9 +42,7 @@ function addDefineInitialPage() {
   const routes = staticConfig.routes;
   const route = routes.find(({ path }) => path === pathname);
   const Page = route.component();
-  Page.__pageConfig = {
-    title: route.window && route.window.title,
-  };
+  Page.__pageConfig = route;
   `;
 }
 

--- a/packages/plugin-ssr/src/ssr/addCustomRenderComponentToHTML.ts
+++ b/packages/plugin-ssr/src/ssr/addCustomRenderComponentToHTML.ts
@@ -33,7 +33,12 @@ export default function addCustomRenderComponentToHTML(
     ${addPageHTMLAssign(useRunApp)}
 
     const documentData = await getInitialProps(Document, ctx);
-    const title = Component.__pageConfig.title;
+    const pageConfig = Component.__pageConfig;
+
+    function getTitle(config) {
+      return config.window && config.window.title
+    }
+    const title = getTitle(pageConfig) || getTitle(staticConfig);
 
     let scripts = ${JSON.stringify(scripts)};
     let styles = ${JSON.stringify(styles)};
@@ -66,7 +71,7 @@ export default function addCustomRenderComponentToHTML(
 
     const $ = new Generator(html);
     if (title) {
-      $.title.innerHTML = Component.__pageConfig.title;
+      $.title.innerHTML = title;
     }
 
     $.insertScript(${JSON.stringify(injectedHTML.scripts || [])});

--- a/packages/plugin-ssr/src/ssr/addPageHTMLAssign.ts
+++ b/packages/plugin-ssr/src/ssr/addPageHTMLAssign.ts
@@ -1,7 +1,10 @@
 export default (useRunApp) => {
   if (!useRunApp) {
     return `
-    const contentElement = createElement(Component, pageInitialProps);
+    const contentElement = createElement(Component, {
+      pageConfig: Component.__pageConfig,
+      ...pageInitialProps,
+    });
     const pageHTML = renderer.renderToString(contentElement, {
       defaultUnit: 'rpx'
     });`;
@@ -10,7 +13,7 @@ export default (useRunApp) => {
     const { setInitialData } = require('rax-app-renderer');
     const raxServerRenderer = require('rax-app-renderer/lib/server').default;
     const { req, res } = ctx;
-    const search = req.search;
+    const search = req.search || '';
     const parsedQuery = parseSearch(search);
     const pathname = req.path;
     const location = { pathname, search, state: null };

--- a/packages/plugin-ssr/src/types.ts
+++ b/packages/plugin-ssr/src/types.ts
@@ -8,8 +8,9 @@ export interface IEntryPluginOptions {
 }
 
 export interface IPageConfig {
-  path: string;
-  title?: string;
+  path?: string;
+  window?: any;
+  [key: string]: any;
 }
 
 export interface ILoaderQuery {

--- a/packages/plugin-ssr/src/utils/getPageConfig.ts
+++ b/packages/plugin-ssr/src/utils/getPageConfig.ts
@@ -1,5 +1,5 @@
-import { WEB } from '../constants';
 import { getMpaEntries } from '@builder/app-helpers';
+import { WEB } from '../constants';
 
 export default function (api, staticConfig) {
   const entries = getMpaEntries(api, {
@@ -7,12 +7,9 @@ export default function (api, staticConfig) {
     appJsonContent: staticConfig,
   });
   const map = {};
-  entries.forEach(({ path: pathname, entryName, window }) => {
+  entries.forEach(({ entryName, entryPath, ...pageConfig }) => {
     if (entryName) {
-      map[entryName] = {
-        path: pathname,
-        title: window?.title || staticConfig?.window?.title,
-      };
+      map[entryName] = pageConfig;
     }
   });
   return map;

--- a/packages/rax-app-renderer/CHANGELOG.md
+++ b/packages/rax-app-renderer/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## v2.0.2
 
 - Feat: throw error when not using the BrowserRouter
+- Chore: `errorBoundary` default value changed to `true`

--- a/packages/rax-app-renderer/CHANGELOG.md
+++ b/packages/rax-app-renderer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0.2
+
+- Feat: throw error when not using the BrowserRouter

--- a/packages/rax-app-renderer/package.json
+++ b/packages/rax-app-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app-renderer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://github.com/alibaba/ice#readme",

--- a/packages/rax-app-renderer/src/renderer.tsx
+++ b/packages/rax-app-renderer/src/renderer.tsx
@@ -161,7 +161,7 @@ async function renderInClient(options) {
 
 export function getRenderAppInstance(runtime, props, options) {
   const { ErrorBoundary, appConfig = {} } = options;
-  const { ErrorBoundaryFallback, onErrorBoundaryHander, errorBoundary } = appConfig.app || {};
+  const { ErrorBoundaryFallback, onErrorBoundaryHander, errorBoundary = true } = appConfig.app || {};
   const AppProvider = runtime?.composeAppProvider?.();
   const RootComponent = () => {
     if (AppProvider) {

--- a/packages/rax-app-renderer/src/server.tsx
+++ b/packages/rax-app-renderer/src/server.tsx
@@ -22,6 +22,9 @@ export default function raxAppRendererWithSSR(context, props, options) {
   if (!appConfig.router) {
     appConfig.router = {};
   }
+  if (appConfig.router.type !== 'browser') {
+    throw new Error('[SSR]: Only support BrowserRouter when using SSR. You should set the router type to "browser". For more detail, please visit https://rax.js.org/docs/guide/route');
+  }
   appConfig.router.type = 'static';
   return renderInServer(context, props, options);
 }

--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -24,7 +24,7 @@
     "build-plugin-rax-pha": "1.4.1",
     "build-plugin-rax-web": "1.4.2",
     "build-plugin-rax-weex": "1.1.1",
-    "build-plugin-ssr": "1.3.6",
+    "build-plugin-ssr": "1.3.7",
     "chokidar": "^3.3.1",
     "commander": "^5.0.0",
     "create-cli-utils": "0.1.6",

--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "command line interface and builtin plugin for rax app",
   "author": "Rax Team",
   "homepage": "https://github.com/alibaba/ice#readme",


### PR DESCRIPTION
## 3.5.1 (April 29 2021)

- Feat: support pass `props.pageConfig` to page component
- Feat: throw error when not using the BrowserRouter
- Chore: `errorBoundary` default value changed to `true`