### PR TITLE
fix: read file content from compiler memfs

### DIFF
--- a/packages/plugin-ssr/src/ssr/setDev.ts
+++ b/packages/plugin-ssr/src/ssr/setDev.ts
@@ -20,7 +20,7 @@ export default function (api, config) {
         // wait until all compiler is done
         if (compilerDoneCount === server.compiler.compilers.length) {
           serverReady = true;
-          httpResponseQueue.forEach(([req, res, next, server]) => {
+          httpResponseQueue.forEach(([req, res, next]) => {
             render(res, req, next, server, api);
           });
           // empty httpResponseQueue
@@ -34,7 +34,7 @@ export default function (api, config) {
       if (serverReady) {
         render(res, req, next, server, api);
       } else {
-        httpResponseQueue.push([req, res, next, server]);
+        httpResponseQueue.push([req, res, next]);
       }
     });
   });


### PR DESCRIPTION
1. 通过 compiler.options.output.path 生成文件路径，避免 output path 被其他插件修改，导致的"找不到文件"问题
2. 从 compiler.outputFileSystem 读取文件代码会更健壮，不依赖 writeToDisk: true

closes #735 