### PR TITLE
fix: console dev url

### DIFF
--- a/packages/plugin-rax-app/src/index.js
+++ b/packages/plugin-rax-app/src/index.js
@@ -20,8 +20,7 @@ module.exports = (api) => {
   setRegisterMethod(api);
 
   setValue(GET_RAX_APP_WEBPACK_CONFIG, getBase);
-  // Set dev url prefix
-  setDevUrlPrefix(api);
+
   setStaticConfig(api);
 
   // register cli option
@@ -29,6 +28,9 @@ module.exports = (api) => {
 
   // register user config
   applyUserConfig(api, { customConfigs });
+
+  // Set dev url prefix
+  setDevUrlPrefix(api);
 
   // modify targets
   modifyTargets(api);

--- a/packages/plugin-rax-app/src/utils/setDevUrlPrefix.js
+++ b/packages/plugin-rax-app/src/utils/setDevUrlPrefix.js
@@ -3,9 +3,9 @@ const { DEV_URL_PREFIX } = require('../constants');
 
 module.exports = (api) => {
   const { setValue, context } = api;
-  const { commandArgs } = context;
+  const { commandArgs, userConfig: { devServer: { host } } } = context;
   const protocol = commandArgs.https ? 'https' : 'http';
-  let urlPrefix = `${protocol}://${ address.ip() }:${ commandArgs.port }`;
+  let urlPrefix = `${protocol}://${ host || address.ip() }:${ commandArgs.port }`;
   if (process.env.CLOUDIDE_ENV) {
     urlPrefix = `https://${process.env.WORKSPACE_UUID}-${commandArgs.port}.${process.env.WORKSPACE_HOST}`;
   }


### PR DESCRIPTION
```json
{
  "devServer": {
    "host": "m.taobao.com"
  }
}
```

修复配置了 devServer host 后，命令行依旧打印 ip 地址作为调试链接的问题