### PR TITLE
chore: change errorBoundary default value

### DIFF
--- a/packages/rax-app-renderer/src/renderer.tsx
+++ b/packages/rax-app-renderer/src/renderer.tsx
@@ -141,7 +141,7 @@ async function renderInClient(options) {
 
 export function getRenderAppInstance(runtime, props, options) {
   const { ErrorBoundary, TabBar, appConfig = {} } = options;
-  const { ErrorBoundaryFallback, onErrorBoundaryHander, onErrorBoundaryHandler, errorBoundary = true } = appConfig.app || {};
+  const { ErrorBoundaryFallback, onErrorBoundaryHander, onErrorBoundaryHandler, errorBoundary } = appConfig.app || {};
   AppTabBar = TabBar;
   const AppProvider = runtime?.composeAppProvider?.();
   const RootComponent = () => {


### PR DESCRIPTION
默认应该关闭 errorBoundary，莫名的 JS 报错出现的兜底组件对业务是有干扰的