### PR TITLE
fix: throw document build error

### DIFF
--- a/examples/basic-mpa-with-document/src/document/index.jsx
+++ b/examples/basic-mpa-with-document/src/document/index.jsx
@@ -13,7 +13,6 @@ function Document(props) {
               name="viewport"
               content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover"
             />
-            <link rel="stylesheet" href={stylesheet} />
             <title>{ props.title }</title>
             <Style />
           </head>

--- a/examples/basic-mpa-with-document/src/document/index.jsx
+++ b/examples/basic-mpa-with-document/src/document/index.jsx
@@ -13,6 +13,7 @@ function Document(props) {
               name="viewport"
               content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover"
             />
+            <link rel="stylesheet" href={stylesheet} />
             <title>{ props.title }</title>
             <Style />
           </head>

--- a/packages/plugin-rax-web/package.json
+++ b/packages/plugin-rax-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-web",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "rax web app plugin",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/plugin-rax-web/src/Plugins/DocumentPlugin.ts
+++ b/packages/plugin-rax-web/src/Plugins/DocumentPlugin.ts
@@ -66,11 +66,18 @@ export default class DocumentPlugin {
             customDocument = true;
             const bundleContent = localBuildAssets[`${entryName}.js`].source();
             const mod = exec(bundleContent, entryPath);
-            html = mod.renderPage(assets, {
-              doctype,
-              title,
-              pagePath,
-            });
+
+            try {
+              html = mod.renderPage(assets, {
+                doctype,
+                title,
+                pagePath,
+              });
+            } catch (error) {
+              compilation.errors.push(error);
+              throw new Error(error.message);
+            }
+
             const parserOptions = { decodeEntities: false };
             const $ = cheerio.load(htmlparser2.parseDOM(html, parserOptions), parserOptions);
             $('#root').after(injectedHTML.scripts);
@@ -82,7 +89,13 @@ export default class DocumentPlugin {
               customDocument = true;
               const bundleContent = localBuildAssets[`${entryName}.js`].source();
               const mod = exec(bundleContent, entryPath);
-              initialHTML = mod.renderPage();
+
+              try {
+                initialHTML = mod.renderPage();
+              } catch (error) {
+                compilation.errors.push(error);
+                throw new Error(error.message);
+              }
             }
 
             html = getBuiltInHtmlTpl({

--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -22,7 +22,7 @@
     "build-plugin-rax-miniapp": "1.4.1",
     "build-plugin-rax-pha": "1.4.4",
     "build-plugin-rax-store": "1.3.1",
-    "build-plugin-rax-web": "1.4.4",
+    "build-plugin-rax-web": "1.4.5",
     "build-plugin-rax-weex": "1.1.2",
     "build-plugin-ssr": "1.3.10",
     "chokidar": "^3.3.1",


### PR DESCRIPTION
In the previous version, if an error was reported during document construction, the construction task would not be interrupted.

Now fixed it.