### PR TITLE
fix: document live load

### DIFF
--- a/packages/plugin-rax-web/src/setLocalBuilder.ts
+++ b/packages/plugin-rax-web/src/setLocalBuilder.ts
@@ -86,7 +86,7 @@ export default (api, documentPath?: string | undefined) => {
 };
 
 function addReloadByDocumentChange(rootDir, entries) {
-  const watcher = chokidar.watch(`${rootDir}/src/document/index.@(tsx|js?(x))`, {
+  const watcher = chokidar.watch(`${rootDir}/src/document/**`, {
     ignoreInitial: true,
     atomic: 300,
   });


### PR DESCRIPTION
Before this PR, files in `src/document` can not trigger rebuild, this bug is fixed in this PR.