### PR TITLE
fix: css is hidden from bundle analyzer report

### DIFF
--- a/packages/plugin-rax-app/src/cliOptions/analyzerTarget.js
+++ b/packages/plugin-rax-app/src/cliOptions/analyzerTarget.js
@@ -4,5 +4,21 @@ module.exports = (config, analyzer, { taskName }) => {
   if (analyzer === taskName) {
     config.plugin('webpack-bundle-analyzer')
       .use(BundleAnalyzerPlugin, [{ analyzerPort: '9000' }]);
+    
+    // MiniCssExtractPlugin.loader will cause css being hidden from bundle analyzer report, remove it here
+    [
+      'css',
+      'less',
+      'scss',
+      'css-module',
+      'less-module',
+      'scss-module'
+    ].forEach((ruleName) => {
+      const rule = config.module.rule(ruleName);
+
+      if (rule.uses.has('MiniCssExtractPlugin.loader')) {
+        rule.uses.delete('MiniCssExtractPlugin.loader');
+      }
+    });
   }
 };


### PR DESCRIPTION
closes #849

以 @alifd/meet 这个包为例

修复前

<img src="https://user-images.githubusercontent.com/9125255/137062697-8f353d86-dc9b-4959-ba06-be3289b24060.png" width="500" />

修复后

<img src="https://user-images.githubusercontent.com/9125255/137062765-9e1ec02f-0094-447f-b0e7-06bb56df62f1.png" width="500" />