### PR TITLE
fix: some edge cases

### DIFF
--- a/packages/plugin-rax-app/src/Loaders/RouteLoader.ts
+++ b/packages/plugin-rax-app/src/Loaders/RouteLoader.ts
@@ -162,7 +162,7 @@ function getComponentName(route: IRoute): string {
   }
   if (route.path === '/') return 'Index';
   // /about => About
-  // /list-a => lista
+  // /list-a => Lista
   return `${route.path[1].toUpperCase()}${route.path.substr(2).replace(/-/, '')}`;
 }
 

--- a/packages/plugin-rax-app/src/Loaders/RouteLoader.ts
+++ b/packages/plugin-rax-app/src/Loaders/RouteLoader.ts
@@ -162,7 +162,8 @@ function getComponentName(route: IRoute): string {
   }
   if (route.path === '/') return 'Index';
   // /about => About
-  return `${route.path[1].toUpperCase()}${route.path.substr(2)}`;
+  // /list-a => lista
+  return `${route.path[1].toUpperCase()}${route.path.substr(2).replace(/-/, '')}`;
 }
 
 function transformAppConfig(jsonContent): IStaticConfig {

--- a/packages/rax-app/src/index.ts
+++ b/packages/rax-app/src/index.ts
@@ -42,14 +42,6 @@ const getBuiltInPlugins: IGetBuiltInPlugins = (userConfig: IRaxAppUserConfig) =>
 
   if (targets.includes('web')) {
     builtInPlugins.push('build-plugin-rax-web');
-    if (userConfig.web) {
-      if (userConfig.web.ssr) {
-        builtInPlugins.push('build-plugin-ssr');
-      }
-      if (userConfig.web.pha) {
-        builtInPlugins.push('build-plugin-rax-pha');
-      }
-    }
   }
 
   if (targets.includes('weex')) {
@@ -64,6 +56,16 @@ const getBuiltInPlugins: IGetBuiltInPlugins = (userConfig: IRaxAppUserConfig) =>
 
   if (isMiniAppTargeted) {
     builtInPlugins.push('build-plugin-rax-miniapp');
+  }
+
+  if (userConfig.web) {
+    if (userConfig.web.pha) {
+      builtInPlugins.push('build-plugin-rax-pha');
+    }
+    // Make ssr plugin after base plugin which need registerTask, the action will override the devServer config
+    if (userConfig.web.ssr) {
+      builtInPlugins.push('build-plugin-ssr');
+    }
   }
 
   if (router) {


### PR DESCRIPTION
- Avoid error when `route.path` with `-`, like: `/list-a`
- SSR plugin order