### PR TITLE
fix: add @babel/plugin-transform-typescript for 'declare'

### DIFF
--- a/packages/rax-babel-config/package.json
+++ b/packages/rax-babel-config/package.json
@@ -26,6 +26,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",
+    "@babel/plugin-transform-typescript": "^7.16.1",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/packages/rax-babel-config/src/index.js
+++ b/packages/rax-babel-config/src/index.js
@@ -54,6 +54,13 @@ module.exports = (userOptions = {}) => {
         require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
         { loose: true },
       ],
+      // https://github.com/babel/babel/releases/tag/v7.16.0, Don't transform declare class in plugin-proposal-class-properties
+      // TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript.
+      // If you have already enabled that plugin (or '@babel/preset-typescript'), make sure that it runs before any plugin related to additional class features:
+      // - @babel/plugin-proposal-class-properties
+      // - @babel/plugin-proposal-private-methods
+      // - @babel/plugin-proposal-decorators
+      require('@babel/plugin-transform-typescript'),
       // Stage 2
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       require.resolve('@babel/plugin-proposal-export-namespace-from'),


### PR DESCRIPTION
https://github.com/babel/babel/releases/tag/v7.16.0. Don't transform declare class in plugin-proposal-class-properties
This is error:
      // TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript.
      // If you have already enabled that plugin (or '@babel/preset-typescript'), make sure that it runs before any plugin related to additional class features:
      // - @babel/plugin-proposal-class-properties
      // - @babel/plugin-proposal-private-methods
      // - @babel/plugin-proposal-decorators
So, add @babel/plugin-transform-typescript for web build.