### PR TITLE
chore: terser plugin sourceMap  default value is depended on webpackConfig.devtool

### DIFF
--- a/packages/rax-webpack-config/CHANELOG.md
+++ b/packages/rax-webpack-config/CHANELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.5
+
+- Chore: `TerserPlugin` `sourceMap` default value is depended on `webpackConfig.devtool`
+
 ## v2.0.4
 
 - Chore: use TypeScript refactor code

--- a/packages/rax-webpack-config/package.json
+++ b/packages/rax-webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-webpack-config",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "rax base webpack config",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-webpack-config/src/webpack.build.ts
+++ b/packages/rax-webpack-config/src/webpack.build.ts
@@ -10,7 +10,6 @@ export default (config) => {
   config.optimization
     .minimizer('TerserPlugin')
     .use(TerserPlugin, [{
-      sourceMap: false,
       cache: true,
       parallel: true,
       extractComments: false,


### PR DESCRIPTION
TerserPlugin `sourceMap` 不应该强制指定，插件内部默认的行为更加合理，即根据 `webpackConfig.devtool` 的值决定是否生成 `sourceMap`