### PR TITLE
chore: avoid to rely on post-preset-env directly

### DIFF
--- a/packages/plugin-rax-app/package.json
+++ b/packages/plugin-rax-app/package.json
@@ -34,7 +34,6 @@
     "mini-css-extract-plugin": "^1.2.1",
     "copy-webpack-plugin": "^5.0.4",
     "postcss-import": "^12.0.1",
-    "postcss-preset-env": "^6.7.0",
     "address": "^1.1.2",
     "chokidar": "^3.5.1",
     "stylesheet-loader": "^0.9.0",
@@ -43,7 +42,8 @@
     "postcss-plugin-rpx2vw": "^0.0.2",
     "process": "^0.11.10",
     "events": "^3.3.0",
-    "node-libs-browser": "^2.2.1"
+    "node-libs-browser": "^2.2.1",
+    "@builder/pack": "^0.5.2"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-rax-app/src/getPostCssPlugin.js
+++ b/packages/plugin-rax-app/src/getPostCssPlugin.js
@@ -18,7 +18,7 @@ module.exports = function getPlugins(type) {
     case 'web':
       return [
         atImport(),
-        require('postcss-preset-env')({
+        require('@builder/pack/deps/postcss-preset-env')({
           autoprefixer: {
             flexbox: 'no-2009',
           },


### PR DESCRIPTION
post-preset-env 版本和 @builder/pack 内置的相同