### PR TITLE
feat: migrate postcss plugin to postcss 8

### DIFF
--- a/packages/postcss-plugin-rpx2vw/package.json
+++ b/packages/postcss-plugin-rpx2vw/package.json
@@ -1,9 +1,12 @@
 {
   "name": "postcss-plugin-rpx2vw",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Postcss plugin transform rpx to vw or rem.",
   "main": "lib/index.js",
-  "dependencies": {
-    "postcss": "^7.0.17"
+  "devDependencies": {
+    "postcss": "^8.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   }
 }

--- a/packages/postcss-plugin-rpx2vw/src/index.js
+++ b/packages/postcss-plugin-rpx2vw/src/index.js
@@ -1,4 +1,3 @@
-const postcss = require('postcss');
 // !singlequotes|!doublequotes|!url()|pixelunit
 const rpxRegex = /"[^"]+"|'[^']+'|url\([^\)]+\)|(\d*\.?\d+)rpx/g;
 


### PR DESCRIPTION
- feat: support render page component
- feat: render document with assets
- feat: support enable sourcemap
- fix: target set order
- v1.4.0
- chore: remove debug code
- fix: duplicate chunkinfo
- fix: ts lint
- fix: render context
- v2.1.0
- fix: render document only
- refactor: api name
- fix: lint
- fix: readme
- refactor: get sourcemap for global config
- refactor: get sourcemap for global config
- fix: css-modules should not add to normal css file (#956)
- chore: add changelog
- chore: optimize code size (#955)
- fix: react-dev-utils socket pathname (#957)
- fix: remove log info
- chore: bump version
- chore: add changelog
- chore: typo
- fix: use `className` and `style` attributes at the same time when `retainClassName` is true (#941)
- feat: migrate to postcss 8
- fix: remove useless deps
