### PR TITLE
fix(plugin-rax-miniapp): setAppCompileConfig staticConfig

### DIFF
--- a/packages/plugin-rax-miniapp/src/index.js
+++ b/packages/plugin-rax-miniapp/src/index.js
@@ -87,10 +87,7 @@ module.exports = (api) => {
             context,
             outputPath,
             entryPath: './src/app',
-            staticConfig: {
-              ...staticConfig,
-              routes: normalRoutes,
-            },
+            staticConfig,
             nativeRoutes,
           });
         } else if (buildType === MINIAPP_BUILD_TYPES.RUNTIME) {


### PR DESCRIPTION
结合 https://github.com/raxjs/miniapp/pull/296 一起看，修复编译时方案下，调用 `setAppConfig` 时 staticConfig.routes 过滤掉了 nativeRoutes，导致 `setEntry`（`setAppConfig` 中）执行过滤 nativeRoutes 时无结果，丢失了 nativeRoutes，最终产物中没将 `src/pages/` 路径下的 '原生小程序页面' 拷贝到产物目录 `build/miniapp/pages/` 下。