### PR TITLE
fix: keepAliveRoutesRef should set initialRoute

### DIFF
--- a/packages/plugin-rax-router/src/runtime/KeepAliveRouter.tsx
+++ b/packages/plugin-rax-router/src/runtime/KeepAliveRouter.tsx
@@ -40,7 +40,7 @@ export default function KeepAliveRouter({ history, routes }) {
       });
       return [];
     }
-    return [route];
+    return (keepAliveRoutesRef.current = [route]);
   });
   // Keep-alive routes
   const [keepAliveRoutes, setKeepAliveRoutes] = useState(initialRoutes);


### PR DESCRIPTION
在获取到 initialRoute 之后，应该更新一下 keepAliveRoutesRef 的值，否则第一个渲染的组件不会包含在 keepAliveRoutesRef 里，导致后面在匹配的时候会出问题。