### PR TITLE
fix(rax-app): debug()  run as needed and optimizing stringify

### DIFF
--- a/packages/plugin-rax-app/CHANGELOG.md
+++ b/packages/plugin-rax-app/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.14
+- Fix: change `debug(JSON.stringify(configs, ...))` to run only in debug mode, and modify the implement of `stringify` that will cause Node16 Crash when `configs` has many circular reference in `logWebpackConfig.js`
+
 ## 7.0.12
 
 - Feat: breaking change for `rax-webpack-config` to update `postcss-loader`

--- a/packages/plugin-rax-app/package.json
+++ b/packages/plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "description": "The basic webpack configuration for rax project",
   "author": "Rax Team",
   "main": "lib/index.js",

--- a/packages/plugin-rax-app/src/utils/logWebpackConfig.ts
+++ b/packages/plugin-rax-app/src/utils/logWebpackConfig.ts
@@ -1,27 +1,14 @@
 import debugCore from 'debug';
+import { inspect } from 'util';
 
 const debug = debugCore('rax-app');
 
 export default (configs) => {
   try {
-    // 用 JSON.stringify 的 replacer 解 cyclic object value 的方式，在 Node16 上面会 Crash，所以改用 util.inspect 实现
-    // https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format
-    // Node Crash 问题，主要出现在 less@^4 importManager.less.importManager 等循环场景，详见 https://code.alibaba-inc.com/clam-eco/clam/issues/550723
-    // 另外，仅在开启 debug 模式下才执行内容，避免干扰普通 build 功能 & 影响性能
+    // Only executed when the debug mode is turned on
     if (debug.enabled) {
-      // const tmp = [];
-      // debug(JSON.stringify(configs, (key, val) => {
-      //   if (val != null && typeof val === 'object') {
-      //     if (tmp.indexOf(val) >= 0) {
-      //       return;
-      //     }
-      //     tmp.push(val);
-      //   }
-      //   return val;
-      // }, 2));
-
-      const configsStr = require('util').inspect(configs, { depth: 10, colors: true });
-      debug(configsStr);
+      // Print webpack configs for easy debugging
+      debug(inspect(configs, { depth: 10, colors: true }));
     }
   } catch (error) {
     // ignore error

--- a/packages/plugin-rax-app/src/utils/logWebpackConfig.ts
+++ b/packages/plugin-rax-app/src/utils/logWebpackConfig.ts
@@ -4,16 +4,25 @@ const debug = debugCore('rax-app');
 
 export default (configs) => {
   try {
-    const tmp = [];
-    debug(JSON.stringify(configs, (key, val) => {
-      if (val != null && typeof val === 'object') {
-        if (tmp.indexOf(val) >= 0) {
-          return;
-        }
-        tmp.push(val);
-      }
-      return val;
-    }, 2));
+    // 用 JSON.stringify 的 replacer 解 cyclic object value 的方式，在 Node16 上面会 Crash，所以改用 util.inspect 实现
+    // https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format
+    // Node Crash 问题，主要出现在 less@^4 importManager.less.importManager 等循环场景，详见 https://code.alibaba-inc.com/clam-eco/clam/issues/550723
+    // 另外，仅在开启 debug 模式下才执行内容，避免干扰普通 build 功能 & 影响性能
+    if (debug.enabled) {
+      // const tmp = [];
+      // debug(JSON.stringify(configs, (key, val) => {
+      //   if (val != null && typeof val === 'object') {
+      //     if (tmp.indexOf(val) >= 0) {
+      //       return;
+      //     }
+      //     tmp.push(val);
+      //   }
+      //   return val;
+      // }, 2));
+
+      const configsStr = require('util').inspect(configs, { depth: 10, colors: true });
+      debug(configsStr);
+    }
   } catch (error) {
     // ignore error
   }


### PR DESCRIPTION
用 JSON.stringify 的 replacer 解 cyclic object value 的方式，在 Node16 上面会 Crash，所以改用 util.inspect 实现. 问题参考：https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format

Node Crash 问题，主要出现在 less@^4 importManager.less.importManager 等循环场景，详见 https://code.alibaba-inc.com/clam-eco/clam/issues/550723
    
另外，仅在执行模式是 debug rax-app 时才执行 debug()，避免对普通 build 执行模式造成影响：功能 + 性能。